### PR TITLE
Perf improvements [wip]

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "react-markdown": "^2.5.0",
     "react-motion": "^0.5.0",
     "react-transition-group": "^2.2.0",
-    "react-typekit": "^1.1.0",
     "tux": "^0.3.0",
     "tux-adapter-contentful": "^0.3.0",
     "universal-router": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-form": "^1.3.0",
     "react-helmet": "^5.1.3",
     "react-intersection-observer": "^1.0.0",
+    "react-lazyload": "^2.3.0",
     "react-markdown": "^2.5.0",
     "react-motion": "^0.5.0",
     "react-transition-group": "^2.2.0",

--- a/src/Html.js
+++ b/src/Html.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import Document, { Html, Head, Body, App, Footer } from 'react-document'
-import TypeKit from 'react-typekit'
 
 /**
  * This component is a template for the HTML file. You can add webfonts, meta tags,
@@ -32,7 +31,6 @@ export default class extends Document {
             helmet.meta.toComponent(),
             helmet.link.toComponent()
           ]}
-          <TypeKit kitId="kee6nkk" />
           <meta property="og:type" content="business.business" />
           <meta property="og:url" content="http://aranja.com/" />
           <meta property="og:title" content="Aranja" />
@@ -55,6 +53,7 @@ export default class extends Document {
           <link rel="preconnect" href="//assets.contentful.com" />
           <link rel="shortcut icon" href="/static/favicon.png" />
           <link rel="manifest" href="/static/manifest.json" />
+          <link rel="stylesheet" href="https://use.typekit.net/kee6nkk.css" />
           <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,IntersectionObserver" defer />
         </Head>
         <Body>

--- a/src/components/Clients/index.js
+++ b/src/components/Clients/index.js
@@ -9,6 +9,7 @@ import nestLogo from './nest.svg'
 import kolibriLogo from './kolibri.svg'
 import lsbLogo from './lsb.svg'
 import upperquadLogo from './uq.svg'
+import LazyLoad from 'react-lazyload'
 import { withReveal } from '../../hoc/withReveal'
 import './styles.scss'
 
@@ -52,7 +53,9 @@ const Clients = ({ clients = defaultClients, isVisible }) => (
     <ul className="Clients-list">
       {clients.map((client, index) => (
         <li className="Clients-item" key={index}>
-          <img className="Clients-image" src={client.logo} alt={client.name} />
+          <LazyLoad once offset={200}>
+            <img className="Clients-image" src={client.logo} alt={client.name} />
+          </LazyLoad>
         </li>
       ))}
     </ul>

--- a/src/components/Page/index.js
+++ b/src/components/Page/index.js
@@ -41,7 +41,7 @@ class Page extends Component {
   }
 
   componentWillUnmount() {
-    window.addEventListener('scroll', throttle(this.onScroll, 100))
+    window.removeEventListener('scroll', throttle(this.onScroll, 100))
     window.removeEventListener('resize', this.onLayout)
   }
 

--- a/src/components/Picture/HeroPicture.js
+++ b/src/components/Picture/HeroPicture.js
@@ -6,51 +6,54 @@ import Picture from './Picture'
 import { withReveal } from '../../hoc/withReveal'
 
 class HeroPicture extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      isMounted: false,
-      isLoaded: false,
-    }
+  state = {
+    isReady: false,
+    isLoaded: false,
   }
 
   onLoad = () => {
     this.setState({ isLoaded: true })
   }
 
+  onReady = () => {
+    this.setState({ isReady: true })
+  }
+
   render() {
-    const { src, cover, parallax, isVisible, ...props } = this.props
-    const { isLoaded } = this.state
+    const { src, cover, isVisible, ...props } = this.props
+    const { isLoaded, isReady } = this.state
 
     if (!Array.isArray(src)) {
       console.error('HeroPicture needs width/height metadata.')
       return <Picture src={src} {...props} />
     }
-
+    
     const smallest = minBy(src, 'width')
     const main = src[0]
     const aspectRatio = main.width / main.height
     const style = !cover ? { paddingTop: `${100 / aspectRatio}%` } : null
 
     return (
-      <picture
-        className={classNames('HeroPicture', isVisible && 'is-visible', isLoaded && 'is-loaded', parallax && 'withParallax')}
+      <div
+        className={classNames('HeroPicture', isVisible && 'is-visible', isLoaded && 'is-loaded')}
         style={style}
       >
-        <Img
-          className="HeroPicture-image"
-          src={src}
-          role="presentation"
-          onLoad={this.onLoad}
-          {...props}
-        />
         <img
           className="HeroPicture-thumbnail"
           src={smallest.src}
-          role="presentation"
-          {...props}
+          onLoad={this.onReady}
         />
-      </picture>
+        {isReady && <picture
+          style={style}>
+          <Img
+            className="HeroPicture-image"
+            src={src}
+            role="presentation"
+            onLoad={this.onLoad}
+            {...props}
+          />
+        </picture>}
+      </div>
     )
   }
 }

--- a/src/components/Picture/HeroPicture.js
+++ b/src/components/Picture/HeroPicture.js
@@ -14,21 +14,13 @@ class HeroPicture extends Component {
     }
   }
 
-  componentWillMount() {
-    this.onLoad = this.onLoad.bind(this)
-  }
-
-  componentDidMount() {
-    this.setState({ isMounted: true })
-  }
-
-  onLoad() {
+  onLoad = () => {
     this.setState({ isLoaded: true })
   }
 
   render() {
     const { src, cover, parallax, isVisible, ...props } = this.props
-    const { isMounted, isLoaded } = this.state
+    const { isLoaded } = this.state
 
     if (!Array.isArray(src)) {
       console.error('HeroPicture needs width/height metadata.')
@@ -45,18 +37,18 @@ class HeroPicture extends Component {
         className={classNames('HeroPicture', isVisible && 'is-visible', isLoaded && 'is-loaded', parallax && 'withParallax')}
         style={style}
       >
-        {isMounted &&
-          <Img
-            className="HeroPicture-image"
-            src={src}
-            role="presentation"
-            onLoad={this.onLoad}
-            {...props}
-          />}
+        <Img
+          className="HeroPicture-image"
+          src={src}
+          role="presentation"
+          onLoad={this.onLoad}
+          {...props}
+        />
         <img
           className="HeroPicture-thumbnail"
           src={smallest.src}
           role="presentation"
+          {...props}
         />
       </picture>
     )

--- a/src/components/Picture/styles.scss
+++ b/src/components/Picture/styles.scss
@@ -26,18 +26,19 @@
 
 .HeroPicture-image,
 .HeroPicture-thumbnail {
-  $offset: 1.5rem;
+  $offset: 10px;
   bottom: -#{$offset};
-  height: calc(100% + #{$offset});
+  height: calc(100% + #{2 * $offset});
   left: -#{$offset};
   position: absolute;
   right: -#{$offset};
   top: -#{$offset};
-  width: calc(100% + #{$offset});
+  width: calc(100% + #{2 * $offset});
 
   .HeroPicture.cover & {
     object-fit: cover;
   }
+
   .HeroPicture.withParallax & {
     transform: translateY(calc(var(--parallax) * #{$offset}));
   }

--- a/src/components/Services/Service.js
+++ b/src/components/Services/Service.js
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import Parallax from '../Parallax'
 import { Body1, H2 } from '../../typography'
 import { withReveal } from '../../hoc/withReveal'
+import LazyLoad from 'react-lazyload'
 import './styles.scss'
 import AnimatedText from '../AnimatedText'
 
@@ -33,12 +34,14 @@ const Service = ({ heading, copy, image, isVisible, index }) => (
     <Parallax clamp>
       <div className="Service-imageWrapper">
         <div className="Service-image" data-animate="image">
-          <div
-            className="Service-imageInner"
-            style={{
-              backgroundImage: `url(${image})`
-            }}
-          />
+          <LazyLoad once offset={200}>
+            <div
+              className="Service-imageInner"
+              style={{
+                backgroundImage: `url(${image})`
+              }}
+            />
+          </LazyLoad>
         </div>
       </div>
     </Parallax>

--- a/src/routes/home/Home.js
+++ b/src/routes/home/Home.js
@@ -7,6 +7,7 @@ import Section from '../../components/Section'
 import Intro from '../../components/Intro'
 import CaseStudyGrid from '../../components/CaseStudyGrid'
 import Clients from '../../components/Clients'
+import LazyLoad from 'react-lazyload'
 import { H2, Body1 } from '../../typography'
 import EditableAnimatedText from '../../components/AnimatedText/EditableAnimatedText'
 import './styles.scss'
@@ -79,7 +80,9 @@ const Home = ({ content, hero, services, showOffs, caseStudies }) => (
           {content.fields.content.portfolioText}
         </EditableAnimatedText>
       </Body1>
-      <CaseStudyGrid caseStudies={caseStudies} />
+      <LazyLoad once offset={200}>
+        <CaseStudyGrid caseStudies={caseStudies} />
+      </LazyLoad>
     </Section>
   </Editable>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -5854,6 +5854,10 @@ react-intersection-observer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-1.0.1.tgz#0bb936f4bb4819dae1945e379a43010a0ffbaf30"
 
+react-lazyload@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-lazyload/-/react-lazyload-2.3.0.tgz#ccb134223012447074a96543954f44b055dc6185"
+
 react-markdown@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-2.5.0.tgz#b1c61904fee5895886803bd9df7db23c3dc3a89e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5905,13 +5905,6 @@ react-transition-group@^2.2.0:
     prop-types "^15.5.8"
     warning "^3.0.0"
 
-react-typekit@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/react-typekit/-/react-typekit-1.1.0.tgz#53e7081587c877d1d80398f6a7d25a5292fd2003"
-  dependencies:
-    lodash "^4.17.4"
-    prop-types "^15.5.10"
-
 "react@^15 || ^16":
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"


### PR DESCRIPTION
By lazy loading images, it seems like we're getting a huge initial load time speed boost. Also, react-typekit was render blocking for a loooong time, so I removed that. Need to adjust lazyload offsets and add to all subpages.

### Things to consider:
- [ ] Don't transition from blue until atf content has been loaded.
- [ ] Cache adapter requests somehow
- [ ] Defer requests regarding content below the fold.
- [ ] Code split by pages

![bitmoji](https://render.bitstrips.com/v2/cpanel/192d631c-0d66-4d06-a2c7-01347e2a4609-cdbae91d-42c2-45f9-80d3-5ff6394b1df6-v1.png?transparent=1&palette=1&width=246)
 